### PR TITLE
Add filesystem chunk utilities for offline updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ characters of the hexadecimal digest.  Any directory created with
 `zck_chunk_store` can be copied to removable media and later consumed by
 `zckdlfs`.
 
+To verify the integrity of an exported chunk directory, run:
+```
+zck_chunk_validate <chunk directory>
+```
+
 To read a zchunk header, run:
 ```
 zck_read_header <file>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ To download a zchunk file, run:
 zckdl -s <source> <url of target>
 ```
 
+To export the compressed chunks from a file for offline transport, run:
+```
+zck_chunk_store -o <chunk directory> <file.zck>
+```
+
+To reconstruct a zchunk file using chunks stored on local media, run:
+```
+zckdlfs -d <chunk directory> [-s <existing file>] <file.zck>
+```
+Chunk files are written beneath the chunk directory as
+`<directory>/<hash>/<prefix>/<digest>.chunk`, where `<hash>` is the chunk
+hash algorithm (for example `sha256`) and `<prefix>` is the first two
+characters of the hexadecimal digest.  Any directory created with
+`zck_chunk_store` can be copied to removable media and later consumed by
+`zckdlfs`.
+
 To read a zchunk header, run:
 ```
 zck_read_header <file>

--- a/doc/zck_chunk_store.1
+++ b/doc/zck_chunk_store.1
@@ -63,7 +63,9 @@ contents are the compressed bytes that appear in the zchunk payload.
 .Pp
 This layout allows the chunk directory to be copied to removable media
 and later consumed by
-.Xr zckdlfs 1 .
+.Xr zckdlfs 1 .  Use
+.Xr zck_chunk_validate 1
+to verify the integrity of an existing chunk directory.
 .Sh EXIT STATUS
 .Ex -std
 .Sh EXAMPLES
@@ -71,6 +73,7 @@ Populate a chunk directory for a previously downloaded image:
 .Pp
 .Dl zck_chunk_store -o /var/lib/zchunk/chunks updates/rootfs.zck
 .Sh SEE ALSO
+.Xr zck_chunk_validate 1 ,
 .Xr zckdlfs 1 ,
 .Xr unzck 1 ,
 .Xr zck 1 ,

--- a/doc/zck_chunk_store.1
+++ b/doc/zck_chunk_store.1
@@ -1,0 +1,84 @@
+.\" Copyright (c) 2024  OpenAI Assistant
+.\" All rights reserved.
+.
+.Dd March 21, 2024
+.Dt ZCK_CHUNK_STORE 1
+.Os
+.Sh NAME
+.Nm zck_chunk_store
+.Nd export compressed chunks from a zchunk file
+.Sh SYNOPSIS
+.Nm
+.Op Fl q | Fl -quiet
+.Op Fl v | Fl -verbose
+.Fl o Ar directory | Fl -output Ns = Ns Ar directory
+.Ar zchunk
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility extracts the compressed payload of every chunk from a zchunk
+file and writes it to a filesystem hierarchy suitable for use with
+.Xr zckdlfs 1 .
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Bl -tag -width indent
+.It Fl q | Fl -quiet
+Quiet operation; only display warning and error messages.  If
+specified twice, only display error messages.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl o | Fl -output
+Directory to populate with chunk files.  The directory will be created
+if necessary.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh OUTPUT LAYOUT
+Each chunk is written as a separate file whose name is derived from the
+chunk digest.  The path for a chunk with digest
+.Ar abcd Ns ...
+and hash type
+.Ar sha256
+is:
+.Bd -literal -offset indent
+<base>/<hash>/<prefix>/<digest>.chunk
+.Ed
+where
+.Ar <base>
+is the directory supplied with
+.Fl o ,
+.Ar <hash>
+is the lowercase chunk hash name, and
+.Ar <prefix>
+is the first two hexadecimal characters of the digest.  The file
+contents are the compressed bytes that appear in the zchunk payload.
+.Pp
+This layout allows the chunk directory to be copied to removable media
+and later consumed by
+.Xr zckdlfs 1 .
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Populate a chunk directory for a previously downloaded image:
+.Pp
+.Dl zck_chunk_store -o /var/lib/zchunk/chunks updates/rootfs.zck
+.Sh SEE ALSO
+.Xr zckdlfs 1 ,
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1
+.Sh AUTHORS
+The
+.Nm
+utility was written by
+.An OpenAI Assistant .

--- a/doc/zck_chunk_validate.1
+++ b/doc/zck_chunk_validate.1
@@ -1,0 +1,61 @@
+.\" Copyright (c) 2024  OpenAI Assistant
+.\" All rights reserved.
+.
+.Dd March 25, 2024
+.Dt ZCK_CHUNK_VALIDATE 1
+.Os
+.Sh NAME
+.Nm zck_chunk_validate
+.Nd verify exported zchunk chunk directories
+.Sh SYNOPSIS
+.Nm
+.Op Fl q | Fl -quiet
+.Op Fl v | Fl -verbose
+.Ar directory
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility scans a directory tree containing compressed chunk payloads
+exported from a zchunk file and verifies that each chunk matches its
+expected checksum.  The directory must follow the layout produced by
+.Xr zck_chunk_store 1
+and consumed by
+.Xr zckdlfs 1 .
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Bl -tag -width indent
+.It Fl q | Fl -quiet
+Quiet operation; only display warning and error messages.  If
+specified twice, only display error messages.
+.It Fl v , Fl -verbose
+Verbose operation; display additional diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Check the integrity of chunk files copied from removable media:
+.Pp
+.Dl zck_chunk_validate /var/lib/zchunk/chunks
+.Sh SEE ALSO
+.Xr zck_chunk_store 1 ,
+.Xr zckdlfs 1 ,
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1
+.Sh AUTHORS
+The
+.Nm
+utility was written by
+.An OpenAI Assistant .

--- a/doc/zckdlfs.1
+++ b/doc/zckdlfs.1
@@ -1,0 +1,97 @@
+.\" Copyright (c) 2024  OpenAI Assistant
+.\" All rights reserved.
+.
+.Dd March 21, 2024
+.Dt ZCKDLFS 1
+.Os
+.Sh NAME
+.Nm zckdlfs
+.Nd reconstruct a zchunk file using a local chunk directory
+.Sh SYNOPSIS
+.Nm
+.Op Fl q | Fl -quiet
+.Op Fl s Ar file | Fl -source Ns = Ns Ar file
+.Op Fl v | Fl -verbose
+.Fl d Ar directory | Fl -chunk-dir Ns = Ns Ar directory
+.Ar zchunk
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility fills the missing chunks of a partially available zchunk
+file by reading the compressed chunk payloads from a local directory
+tree.  The directory must be organised as described below.  This
+allows transporting chunk data using removable media instead of HTTP
+range requests while preserving the integrity checks performed by the
+zchunk format.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Bl -tag -width indent
+.It Fl q | Fl -quiet
+Quiet operation; only display warning and error messages.  If
+specified twice, only display error messages.
+.It Fl s | Fl -source
+Specify the file to use as a source with the premise that most of the
+chunks in the reconstructed file will be the same.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl d | Fl -chunk-dir
+Directory containing compressed chunk files.  Each chunk is stored as
+an individual file named after its checksum.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh CHUNK DIRECTORY LAYOUT
+The chunk directory is split by checksum type and digest prefix to
+keep the number of files per directory manageable.  The expected
+layout for a chunk with digest
+.Ar abcd Ns ...
+and hash type
+.Ar sha256
+is:
+.Bd -literal -offset indent
+<base>/<hash>/<prefix>/<digest>.chunk
+.Ed
+where
+.Ar <base>
+is the directory supplied with
+.Fl d ,
+.Ar <hash>
+is the lowercase chunk hash name reported by
+.Xr zck_read_header 1 ,
+.Ar <prefix>
+is the first two hexadecimal characters of the digest, and
+.Ar <digest>
+is the full chunk digest.
+.Pp
+The
+.Xr zck_chunk_store 1
+utility can populate a directory tree in this format from an existing
+zchunk file.
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Rebuild an image from chunks provided on a USB drive:
+.Pp
+.Dl zckdlfs -d /mnt/usb/chunks -s old-image.zck new-image.zck
+.Sh SEE ALSO
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_chunk_store 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1
+.Sh AUTHORS
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+The filesystem chunk support was contributed by
+.An OpenAI Assistant .

--- a/doc/zckdlfs.1
+++ b/doc/zckdlfs.1
@@ -74,7 +74,9 @@ is the full chunk digest.
 The
 .Xr zck_chunk_store 1
 utility can populate a directory tree in this format from an existing
-zchunk file.
+zchunk file, and
+.Xr zck_chunk_validate 1
+can be used to confirm the integrity of transported chunks before importing them.
 .Sh EXIT STATUS
 .Ex -std
 .Sh EXAMPLES
@@ -85,6 +87,7 @@ Rebuild an image from chunks provided on a USB drive:
 .Xr unzck 1 ,
 .Xr zck 1 ,
 .Xr zck_chunk_store 1 ,
+.Xr zck_chunk_validate 1 ,
 .Xr zck_delta_size 1 ,
 .Xr zck_gen_zdict 1 ,
 .Xr zck_read_header 1

--- a/meson.build
+++ b/meson.build
@@ -94,6 +94,7 @@ if get_option('docs')
         'doc/zckdl.1',
         'doc/zckdlfs.1',
         'doc/zck_chunk_store.1',
+        'doc/zck_chunk_validate.1',
     ])
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,8 @@ if get_option('docs')
         'doc/zck_gen_zdict.1',
         'doc/zck_read_header.1',
         'doc/zckdl.1',
+        'doc/zckdlfs.1',
+        'doc/zck_chunk_store.1',
     ])
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -73,6 +73,25 @@ zck_chunk_store = executable(
     install: true,
     c_args: preprocessor_defines
 )
+chunk_validate_sources = ['zck_chunk_validate.c', 'util_common.c']
+chunk_validate_deps = [argplib]
+if not openssl_dep.found()
+    chunk_validate_sources += [
+        'lib/hash/bundled/sha1/sha1.c',
+        'lib/hash/bundled/sha2/sha2.c',
+    ]
+else
+    chunk_validate_deps += openssl_dep
+endif
+zck_chunk_validate = executable(
+    'zck_chunk_validate',
+    chunk_validate_sources + extra_win_src,
+    include_directories: inc,
+    dependencies: chunk_validate_deps,
+    link_with: zcklib,
+    install: true,
+    c_args: preprocessor_defines
+)
 zckdlfs = executable(
     'zckdlfs',
     ['zck_dl_dir.c', 'util_common.c'] + extra_win_src,

--- a/src/meson.build
+++ b/src/meson.build
@@ -64,3 +64,21 @@ zckdl = executable(
     install: true,
     c_args: preprocessor_defines
 )
+zck_chunk_store = executable(
+    'zck_chunk_store',
+    ['zck_chunk_store.c', 'util_common.c'] + extra_win_src,
+    include_directories: inc,
+    dependencies: argplib,
+    link_with: zcklib,
+    install: true,
+    c_args: preprocessor_defines
+)
+zckdlfs = executable(
+    'zckdlfs',
+    ['zck_dl_dir.c', 'util_common.c'] + extra_win_src,
+    include_directories: inc,
+    dependencies: argplib,
+    link_with: zcklib,
+    install: true,
+    c_args: preprocessor_defines
+)

--- a/src/zck_chunk_store.c
+++ b/src/zck_chunk_store.c
@@ -166,10 +166,6 @@ int main(int argc, char *argv[]) {
         LOG_ERROR("%s", zck_get_error(zck));
         exit(10);
     }
-    if(!zck_read_lead(zck) || !zck_read_header(zck)) {
-        LOG_ERROR("%s", zck_get_error(zck));
-        exit(10);
-    }
 
     const char *hash_name = zck_hash_name_from_type(zck_get_chunk_hash_type(zck));
     if(hash_name == NULL) {

--- a/src/zck_chunk_store.c
+++ b/src/zck_chunk_store.c
@@ -252,23 +252,23 @@ int main(int argc, char *argv[]) {
             exit(10);
         }
 
-            if(comp_size > 0) {
-                char *buffer = calloc(comp_size, 1);
-                if(buffer == NULL) {
-                    close(chunk_fd);
-                    free(chunk_path);
-                    free(prefix_dir);
-                    free(digest);
-                    free(hash_dir);
-                    exit(10);
-                }
-                ssize_t read_size =
+        if(comp_size > 0) {
+            char *buffer = calloc(comp_size, 1);
+            if(buffer == NULL) {
+                close(chunk_fd);
+                free(chunk_path);
+                free(prefix_dir);
+                free(digest);
+                free(hash_dir);
+                exit(10);
+            }
+            ssize_t read_size =
                 zck_get_chunk_comp_data(chunk, buffer, (size_t)comp_size);
-                if(read_size != comp_size) {
-                    if(read_size < 0)
-                        LOG_ERROR("%s", zck_get_error(zck));
-                    else
-                        LOG_ERROR(
+            if(read_size != comp_size) {
+                if(read_size < 0)
+                    LOG_ERROR("%s", zck_get_error(zck));
+                else
+                    LOG_ERROR(
                         "Chunk %lli size mismatch: expected %lli, read %lli\n",
                         (long long)zck_get_chunk_number(chunk),
                         (long long)comp_size,

--- a/src/zck_chunk_store.c
+++ b/src/zck_chunk_store.c
@@ -1,0 +1,319 @@
+#include <argp.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+#include <zck.h>
+
+#include "util_common.h"
+
+static char doc[] =
+    "zck_chunk_store - Export compressed zchunk chunks to a chunk directory";
+
+static char args_doc[] = "<zchunk file>";
+
+struct arguments {
+    char *args[1];
+    zck_log_type log_level;
+    char *output_dir;
+    bool exit;
+};
+
+static struct argp_option options[] = {
+    {"verbose", 'v', 0, 0, "Increase verbosity"},
+    {"quiet", 'q', 0, 0,
+     "Only show warnings (can be specified twice to only show errors)"},
+    {"output", 'o', "DIR", 0, "Directory to populate with chunk files"},
+    {"version", 'V', 0, 0, "Show program version"},
+    {0}
+};
+
+static bool ensure_dir(const char *path) {
+    struct stat st = {0};
+    if(stat(path, &st) == 0) {
+        if(S_ISDIR(st.st_mode))
+            return true;
+        errno = ENOTDIR;
+        return false;
+    }
+#ifdef _WIN32
+    if(_mkdir(path) == -1 && errno != EEXIST)
+        return false;
+#else
+    if(mkdir(path, 0777) == -1 && errno != EEXIST)
+        return false;
+#endif
+    return true;
+}
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    struct arguments *arguments = state->input;
+
+    if(arguments->exit)
+        return 0;
+
+    switch(key) {
+        case 'v':
+            if(arguments->log_level > ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level--;
+            if(arguments->log_level < ZCK_LOG_DDEBUG)
+                arguments->log_level = ZCK_LOG_DDEBUG;
+            break;
+        case 'q':
+            if(arguments->log_level < ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level += 1;
+            if(arguments->log_level > ZCK_LOG_NONE)
+                arguments->log_level = ZCK_LOG_NONE;
+            break;
+        case 'o':
+            arguments->output_dir = arg;
+            break;
+        case 'V':
+            version();
+            arguments->exit = true;
+            break;
+        case ARGP_KEY_ARG:
+            if(state->arg_num >= 1) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            arguments->args[state->arg_num] = arg;
+            break;
+        case ARGP_KEY_END:
+            if(state->arg_num < 1) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+static char *build_chunk_path(const char *base, const char *hash_name,
+                              const char *digest) {
+    size_t digest_len = strlen(digest);
+    const char *subdir = "zz";
+    char prefix[3] = {0};
+    if(digest_len >= 2) {
+        prefix[0] = digest[0];
+        prefix[1] = digest[1];
+    } else {
+        prefix[0] = 's';
+        prefix[1] = 'm';
+    }
+    prefix[2] = '\0';
+    subdir = prefix;
+
+    size_t path_len = strlen(base) + strlen(hash_name) + strlen(subdir) +
+                      strlen(digest) + strlen("///.chunk") + 1;
+    char *path = calloc(path_len, 1);
+    if(path == NULL)
+        return NULL;
+    snprintf(path, path_len, "%s/%s/%s/%s.chunk", base, hash_name, subdir,
+             digest);
+    return path;
+}
+
+int main(int argc, char *argv[]) {
+    struct arguments arguments = {0};
+    arguments.log_level = ZCK_LOG_INFO;
+
+    int retval = argp_parse(&argp, argc, argv, 0, 0, &arguments);
+    if(retval || arguments.exit)
+        exit(retval);
+
+    if(arguments.output_dir == NULL) {
+        LOG_ERROR("--output must be specified\n");
+        exit(2);
+    }
+
+    zck_set_log_level(arguments.log_level);
+
+    int src_fd = open(arguments.args[0], O_RDONLY | O_BINARY);
+    if(src_fd < 0) {
+        LOG_ERROR("Unable to open %s\n", arguments.args[0]);
+        perror(NULL);
+        exit(10);
+    }
+
+    if(!ensure_dir(arguments.output_dir)) {
+        LOG_ERROR("Unable to create %s: %s\n", arguments.output_dir,
+                  strerror(errno));
+        exit(10);
+    }
+
+    zckCtx *zck = zck_create();
+    if(zck == NULL)
+        exit(10);
+    if(!zck_init_read(zck, src_fd)) {
+        LOG_ERROR("%s", zck_get_error(zck));
+        exit(10);
+    }
+    if(!zck_read_lead(zck) || !zck_read_header(zck)) {
+        LOG_ERROR("%s", zck_get_error(zck));
+        exit(10);
+    }
+
+    const char *hash_name = zck_hash_name_from_type(zck_get_chunk_hash_type(zck));
+    if(hash_name == NULL) {
+        LOG_ERROR("Unable to determine chunk hash type\n");
+        exit(10);
+    }
+
+    char *hash_dir = NULL;
+    size_t hash_dir_len = strlen(arguments.output_dir) + strlen(hash_name) + 2;
+    hash_dir = calloc(hash_dir_len, 1);
+    if(hash_dir == NULL)
+        exit(10);
+    snprintf(hash_dir, hash_dir_len, "%s/%s", arguments.output_dir, hash_name);
+    if(!ensure_dir(hash_dir)) {
+        LOG_ERROR("Unable to create %s: %s\n", hash_dir, strerror(errno));
+        free(hash_dir);
+        exit(10);
+    }
+
+    size_t chunk_count = 0;
+    size_t bytes_written = 0;
+
+    for(zckChunk *chunk = zck_get_first_chunk(zck); chunk;
+        chunk = zck_get_next_chunk(chunk)) {
+        char *digest = zck_get_chunk_digest(chunk);
+        if(digest == NULL) {
+            LOG_ERROR("Unable to get chunk digest\n");
+            free(hash_dir);
+            exit(10);
+        }
+        char prefix[3] = {0};
+        size_t digest_len = strlen(digest);
+        if(digest_len >= 2) {
+            prefix[0] = digest[0];
+            prefix[1] = digest[1];
+        } else {
+            prefix[0] = 's';
+            prefix[1] = 'm';
+        }
+        prefix[2] = '\0';
+        size_t prefix_dir_len = strlen(hash_dir) + strlen(prefix) + 2;
+        char *prefix_dir = calloc(prefix_dir_len, 1);
+        if(prefix_dir == NULL) {
+            free(digest);
+            free(hash_dir);
+            exit(10);
+        }
+        snprintf(prefix_dir, prefix_dir_len, "%s/%s", hash_dir, prefix);
+        if(!ensure_dir(prefix_dir)) {
+            LOG_ERROR("Unable to create %s: %s\n", prefix_dir, strerror(errno));
+            free(digest);
+            free(prefix_dir);
+            free(hash_dir);
+            exit(10);
+        }
+
+        char *chunk_path = build_chunk_path(arguments.output_dir, hash_name,
+                                            digest);
+        if(chunk_path == NULL) {
+            free(prefix_dir);
+            free(digest);
+            free(hash_dir);
+            exit(10);
+        }
+
+        int chunk_fd =
+            open(chunk_path, O_TRUNC | O_WRONLY | O_CREAT | O_BINARY, 0666);
+        if(chunk_fd < 0) {
+            LOG_ERROR("Unable to open %s: %s\n", chunk_path, strerror(errno));
+            free(chunk_path);
+            free(prefix_dir);
+            free(digest);
+            free(hash_dir);
+            exit(10);
+        }
+
+        ssize_t comp_size = zck_get_chunk_comp_size(chunk);
+        if(comp_size < 0) {
+            LOG_ERROR("%s", zck_get_error(zck));
+            close(chunk_fd);
+            free(chunk_path);
+            free(digest);
+            free(hash_dir);
+            exit(10);
+        }
+
+            if(comp_size > 0) {
+                char *buffer = calloc(comp_size, 1);
+                if(buffer == NULL) {
+                    close(chunk_fd);
+                    free(chunk_path);
+                    free(prefix_dir);
+                    free(digest);
+                    free(hash_dir);
+                    exit(10);
+                }
+                ssize_t read_size =
+                zck_get_chunk_comp_data(chunk, buffer, (size_t)comp_size);
+                if(read_size != comp_size) {
+                    if(read_size < 0)
+                        LOG_ERROR("%s", zck_get_error(zck));
+                    else
+                        LOG_ERROR(
+                        "Chunk %lli size mismatch: expected %lli, read %lli\n",
+                        (long long)zck_get_chunk_number(chunk),
+                        (long long)comp_size,
+                        (long long)read_size);
+                free(buffer);
+                close(chunk_fd);
+                free(chunk_path);
+                free(prefix_dir);
+                free(digest);
+                free(hash_dir);
+                exit(10);
+            }
+            if(write(chunk_fd, buffer, comp_size) != comp_size) {
+                LOG_ERROR("Unable to write %s: %s\n", chunk_path,
+                          strerror(errno));
+                free(buffer);
+                close(chunk_fd);
+                free(chunk_path);
+                free(prefix_dir);
+                free(digest);
+                free(hash_dir);
+                exit(10);
+            }
+            bytes_written += comp_size;
+            free(buffer);
+        }
+
+        close(chunk_fd);
+        free(chunk_path);
+        free(prefix_dir);
+        free(digest);
+        chunk_count++;
+    }
+
+    printf("Stored %llu chunks (%llu bytes) in %s\n",
+           (long long unsigned)chunk_count,
+           (long long unsigned)bytes_written,
+           arguments.output_dir);
+
+    free(hash_dir);
+    zck_free(&zck);
+    close(src_fd);
+    return 0;
+}

--- a/src/zck_chunk_validate.c
+++ b/src/zck_chunk_validate.c
@@ -1,0 +1,605 @@
+#include <argp.h>
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <zck.h>
+
+#include "util_common.h"
+
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+#include <openssl/evp.h>
+#else
+#include "lib/hash/bundled/sha1/sha1.h"
+#include "lib/hash/bundled/sha2/sha2.h"
+#endif
+
+static char doc[] =
+    "zck_chunk_validate - Validate exported zchunk chunk files";
+
+static char args_doc[] = "<chunk directory>";
+
+struct arguments {
+    char *args[1];
+    zck_log_type log_level;
+    bool exit;
+};
+
+static struct argp_option options[] = {
+    {"verbose", 'v', 0, 0, "Increase verbosity"},
+    {"quiet", 'q', 0, 0,
+     "Only show warnings (can be specified twice to only show errors)"},
+    {"version", 'V', 0, 0, "Show program version"},
+    {0},
+};
+
+struct stats {
+    size_t files;
+    size_t valid;
+    size_t zero;
+    size_t digest_errors;
+    size_t io_errors;
+    size_t name_errors;
+    size_t size_errors;
+};
+
+struct digest_ctx {
+    int type;
+    size_t digest_size;
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+    EVP_MD_CTX *ctx;
+#else
+    union {
+        SHA_CTX sha1;
+        sha256_ctx sha256;
+        sha512_ctx sha512;
+    } state;
+#endif
+};
+
+static size_t digest_size_for_type(int hash_type) {
+    switch(hash_type) {
+        case ZCK_HASH_SHA1:
+            return 20;
+        case ZCK_HASH_SHA256:
+            return 32;
+        case ZCK_HASH_SHA512:
+            return 64;
+        case ZCK_HASH_SHA512_128:
+            return 16;
+        default:
+            return 0;
+    }
+}
+
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+static const EVP_MD *digest_evp_for_type(int hash_type) {
+    switch(hash_type) {
+        case ZCK_HASH_SHA1:
+            return EVP_sha1();
+        case ZCK_HASH_SHA256:
+            return EVP_sha256();
+        case ZCK_HASH_SHA512:
+        case ZCK_HASH_SHA512_128:
+            return EVP_sha512();
+        default:
+            return NULL;
+    }
+}
+#endif
+
+static bool digest_ctx_init(struct digest_ctx *ctx, int hash_type) {
+    ctx->type = hash_type;
+    ctx->digest_size = digest_size_for_type(hash_type);
+    if(ctx->digest_size == 0)
+        return false;
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+    const EVP_MD *md = digest_evp_for_type(hash_type);
+    if(md == NULL)
+        return false;
+    ctx->ctx = EVP_MD_CTX_new();
+    if(ctx->ctx == NULL)
+        return false;
+    if(EVP_DigestInit_ex(ctx->ctx, md, NULL) != 1) {
+        EVP_MD_CTX_free(ctx->ctx);
+        ctx->ctx = NULL;
+        return false;
+    }
+#else
+    switch(hash_type) {
+        case ZCK_HASH_SHA1:
+            SHA1_Init(&ctx->state.sha1);
+            break;
+        case ZCK_HASH_SHA256:
+            sha256_init(&ctx->state.sha256);
+            break;
+        case ZCK_HASH_SHA512:
+        case ZCK_HASH_SHA512_128:
+            sha512_init(&ctx->state.sha512);
+            break;
+        default:
+            return false;
+    }
+#endif
+    return true;
+}
+
+static void digest_ctx_cleanup(struct digest_ctx *ctx) {
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+    if(ctx->ctx)
+        EVP_MD_CTX_free(ctx->ctx);
+    ctx->ctx = NULL;
+#else
+    (void)ctx;
+#endif
+}
+
+static bool digest_ctx_update(struct digest_ctx *ctx, const unsigned char *data,
+                              size_t len) {
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+    if(EVP_DigestUpdate(ctx->ctx, data, len) != 1)
+        return false;
+#else
+    switch(ctx->type) {
+        case ZCK_HASH_SHA1:
+            SHA1_Update(&ctx->state.sha1, data, (unsigned int)len);
+            break;
+        case ZCK_HASH_SHA256:
+            sha256_update(&ctx->state.sha256, data, (unsigned int)len);
+            break;
+        case ZCK_HASH_SHA512:
+        case ZCK_HASH_SHA512_128:
+            sha512_update(&ctx->state.sha512, data, (unsigned int)len);
+            break;
+        default:
+            return false;
+    }
+#endif
+    return true;
+}
+
+static bool digest_ctx_finalize(struct digest_ctx *ctx, unsigned char **out) {
+    size_t digest_len = ctx->digest_size;
+    const unsigned char *digest_src = NULL;
+#if defined(ZCHUNK_OPENSSL) && !defined(ZCHUNK_OPENSSL_DEPRECATED)
+    unsigned int result_len = 0;
+    unsigned char temp[EVP_MAX_MD_SIZE];
+    if(EVP_DigestFinal_ex(ctx->ctx, temp, &result_len) != 1) {
+        digest_ctx_cleanup(ctx);
+        return false;
+    }
+    digest_ctx_cleanup(ctx);
+    if(ctx->type == ZCK_HASH_SHA512_128) {
+        if(result_len < 16)
+            return false;
+        digest_len = 16;
+    } else if(result_len < digest_len) {
+        return false;
+    }
+    digest_src = temp;
+#else
+    unsigned char temp[SHA512_DIGEST_SIZE];
+    switch(ctx->type) {
+        case ZCK_HASH_SHA1:
+            SHA1_Final(temp, &ctx->state.sha1);
+            break;
+        case ZCK_HASH_SHA256:
+            sha256_final(&ctx->state.sha256, temp);
+            break;
+        case ZCK_HASH_SHA512:
+            sha512_final(&ctx->state.sha512, temp);
+            break;
+        case ZCK_HASH_SHA512_128:
+            sha512_final(&ctx->state.sha512, temp);
+            digest_len = 16;
+            break;
+        default:
+            return false;
+    }
+    digest_src = temp;
+#endif
+    unsigned char *buffer = calloc(digest_len, 1);
+    if(buffer == NULL)
+        return false;
+    memcpy(buffer, digest_src, digest_len);
+    *out = buffer;
+    return true;
+}
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    struct arguments *arguments = state->input;
+
+    if(arguments->exit)
+        return 0;
+
+    switch(key) {
+        case 'v':
+            if(arguments->log_level > ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level--;
+            if(arguments->log_level < ZCK_LOG_DDEBUG)
+                arguments->log_level = ZCK_LOG_DDEBUG;
+            break;
+        case 'q':
+            if(arguments->log_level < ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level += 1;
+            if(arguments->log_level > ZCK_LOG_NONE)
+                arguments->log_level = ZCK_LOG_NONE;
+            break;
+        case 'V':
+            version();
+            arguments->exit = true;
+            break;
+        case ARGP_KEY_ARG:
+            if(state->arg_num >= 1) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            arguments->args[state->arg_num] = arg;
+            break;
+        case ARGP_KEY_END:
+            if(state->arg_num < 1) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+static int hash_type_from_name(const char *name) {
+    for(int type = ZCK_HASH_SHA1; type < ZCK_HASH_UNKNOWN; type++) {
+        const char *candidate = zck_hash_name_from_type(type);
+        if(candidate && strcmp(candidate, name) == 0)
+            return type;
+    }
+    return -1;
+}
+
+static bool ends_with(const char *name, const char *suffix) {
+    size_t name_len = strlen(name);
+    size_t suffix_len = strlen(suffix);
+    if(name_len < suffix_len)
+        return false;
+    return strcmp(name + name_len - suffix_len, suffix) == 0;
+}
+
+static bool is_hex_string(const char *s) {
+    for(const char *p = s; *p; p++) {
+        if(!isxdigit((unsigned char)*p))
+            return false;
+    }
+    return true;
+}
+
+static bool is_zero_digest(const char *digest) {
+    for(const char *p = digest; *p; p++) {
+        if(*p != '0')
+            return false;
+    }
+    return true;
+}
+
+static char *join2(const char *a, const char *b) {
+    size_t len = strlen(a) + strlen(b) + 2;
+    char *path = calloc(len, 1);
+    if(path == NULL)
+        return NULL;
+    snprintf(path, len, "%s/%s", a, b);
+    return path;
+}
+
+static char *join3(const char *a, const char *b, const char *c) {
+    size_t len = strlen(a) + strlen(b) + strlen(c) + 3;
+    char *path = calloc(len, 1);
+    if(path == NULL)
+        return NULL;
+    snprintf(path, len, "%s/%s/%s", a, b, c);
+    return path;
+}
+
+static char *join4(const char *a, const char *b, const char *c, const char *d) {
+    size_t len = strlen(a) + strlen(b) + strlen(c) + strlen(d) + 4;
+    char *path = calloc(len, 1);
+    if(path == NULL)
+        return NULL;
+    snprintf(path, len, "%s/%s/%s/%s", a, b, c, d);
+    return path;
+}
+
+static char *dup_prefix(const char *src, size_t len) {
+    char *out = calloc(len + 1, 1);
+    if(out == NULL)
+        return NULL;
+    memcpy(out, src, len);
+    return out;
+}
+
+static char *digest_to_hex(const unsigned char *digest, size_t length) {
+    char *hex = calloc(length * 2 + 1, 1);
+    if(hex == NULL)
+        return NULL;
+    for(size_t i = 0; i < length; i++)
+        snprintf(hex + i * 2, 3, "%02x", digest[i]);
+    return hex;
+}
+
+static bool validate_chunk_file(const char *path, const char *digest,
+                                int hash_type, struct stats *stats) {
+    stats->files++;
+
+    struct stat st = {0};
+    if(stat(path, &st) < 0) {
+        LOG_ERROR("Unable to stat %s: %s\n", path, strerror(errno));
+        stats->io_errors++;
+        return false;
+    }
+
+    size_t digest_bytes = digest_size_for_type(hash_type);
+    if(digest_bytes == 0) {
+        LOG_ERROR("Unsupported hash type for %s\n", path);
+        stats->name_errors++;
+        return false;
+    }
+
+    size_t expected_len = digest_bytes * 2;
+    if(strlen(digest) != expected_len || !is_hex_string(digest)) {
+        LOG_ERROR("Invalid chunk name %s (expected %zu hex characters)\n",
+                  digest, expected_len);
+        stats->name_errors++;
+        return false;
+    }
+
+    if(is_zero_digest(digest)) {
+        if(st.st_size != 0) {
+            LOG_ERROR("Chunk %s has zero digest but non-zero length\n", path);
+            stats->size_errors++;
+            return false;
+        }
+        stats->zero++;
+        stats->valid++;
+        return true;
+    }
+
+    int fd = open(path, O_RDONLY | O_BINARY);
+    if(fd < 0) {
+        LOG_ERROR("Unable to open %s: %s\n", path, strerror(errno));
+        stats->io_errors++;
+        return false;
+    }
+
+    struct digest_ctx ctx = {0};
+    if(!digest_ctx_init(&ctx, hash_type)) {
+        LOG_ERROR("Unable to initialize digest context for %s\n", path);
+        close(fd);
+        stats->io_errors++;
+        return false;
+    }
+
+    bool error = false;
+    unsigned char buffer[BUF_SIZE];
+    while(true) {
+        ssize_t rb = read(fd, buffer, sizeof(buffer));
+        if(rb < 0) {
+            LOG_ERROR("Error reading %s: %s\n", path, strerror(errno));
+            error = true;
+            break;
+        }
+        if(rb == 0)
+            break;
+        if(!digest_ctx_update(&ctx, buffer, (size_t)rb)) {
+            LOG_ERROR("Unable to update digest for %s\n", path);
+            error = true;
+            break;
+        }
+    }
+
+    close(fd);
+
+    if(error) {
+        digest_ctx_cleanup(&ctx);
+        stats->io_errors++;
+        return false;
+    }
+
+    unsigned char *digest_raw = NULL;
+    if(!digest_ctx_finalize(&ctx, &digest_raw)) {
+        stats->io_errors++;
+        return false;
+    }
+
+    char *digest_hex = digest_to_hex(digest_raw, digest_bytes);
+    free(digest_raw);
+    if(digest_hex == NULL) {
+        stats->io_errors++;
+        return false;
+    }
+
+    bool match = strcmp(digest_hex, digest) == 0;
+    if(!match) {
+        LOG_ERROR("Digest mismatch for %s\n", path);
+        stats->digest_errors++;
+    } else {
+        stats->valid++;
+    }
+
+    free(digest_hex);
+    return match;
+}
+
+static bool validate_prefix_dir(const char *base, const char *hash_name,
+                                const char *prefix, int hash_type,
+                                struct stats *stats) {
+    char *prefix_path = join3(base, hash_name, prefix);
+    if(prefix_path == NULL)
+        return false;
+
+    DIR *dir = opendir(prefix_path);
+    if(dir == NULL) {
+        LOG_ERROR("Unable to open %s: %s\n", prefix_path, strerror(errno));
+        free(prefix_path);
+        return false;
+    }
+
+    bool ok = true;
+    struct dirent *entry = NULL;
+    while((entry = readdir(dir)) != NULL) {
+        if(strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
+        if(!ends_with(entry->d_name, ".chunk")) {
+            LOG_ERROR("Skipping unexpected file %s/%s\n", prefix_path,
+                      entry->d_name);
+            stats->name_errors++;
+            ok = false;
+            continue;
+        }
+        size_t name_len = strlen(entry->d_name);
+        size_t digest_len = name_len - strlen(".chunk");
+        char *digest = dup_prefix(entry->d_name, digest_len);
+        if(digest == NULL) {
+            ok = false;
+            break;
+        }
+        char *chunk_path = join4(base, hash_name, prefix, entry->d_name);
+        if(chunk_path == NULL) {
+            free(digest);
+            ok = false;
+            break;
+        }
+        bool chunk_ok = validate_chunk_file(chunk_path, digest, hash_type, stats);
+        if(!chunk_ok)
+            ok = false;
+        free(chunk_path);
+        free(digest);
+    }
+
+    closedir(dir);
+    free(prefix_path);
+    return ok;
+}
+
+static bool validate_hash_dir(const char *base, const char *hash_name,
+                              struct stats *stats) {
+    int hash_type_id = hash_type_from_name(hash_name);
+    if(hash_type_id < 0) {
+        LOG_ERROR("Skipping unknown hash directory %s\n", hash_name);
+        stats->name_errors++;
+        return false;
+    }
+
+    char *hash_path = join2(base, hash_name);
+    if(hash_path == NULL)
+        return false;
+
+    DIR *dir = opendir(hash_path);
+    if(dir == NULL) {
+        LOG_ERROR("Unable to open %s: %s\n", hash_path, strerror(errno));
+        free(hash_path);
+        return false;
+    }
+
+    bool ok = true;
+    struct dirent *entry = NULL;
+    while((entry = readdir(dir)) != NULL) {
+        if(strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
+        char *prefix_path = join3(base, hash_name, entry->d_name);
+        if(prefix_path == NULL) {
+            ok = false;
+            break;
+        }
+        free(prefix_path);
+        if(!validate_prefix_dir(base, hash_name, entry->d_name, hash_type_id,
+                                 stats))
+            ok = false;
+    }
+
+    closedir(dir);
+    free(hash_path);
+    return ok;
+}
+
+int main(int argc, char *argv[]) {
+    struct arguments arguments = {0};
+    arguments.log_level = ZCK_LOG_INFO;
+
+    int retval = argp_parse(&argp, argc, argv, 0, 0, &arguments);
+    if(retval || arguments.exit)
+        exit(retval);
+
+    zck_set_log_level(arguments.log_level);
+
+    const char *chunk_dir = arguments.args[0];
+    DIR *base_dir = opendir(chunk_dir);
+    if(base_dir == NULL) {
+        LOG_ERROR("Unable to open %s: %s\n", chunk_dir, strerror(errno));
+        exit(10);
+    }
+
+    struct stats stats = {0};
+    bool ok = true;
+    struct dirent *entry = NULL;
+    while((entry = readdir(base_dir)) != NULL) {
+        if(strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            continue;
+        char *hash_path = join2(chunk_dir, entry->d_name);
+        if(hash_path == NULL) {
+            ok = false;
+            break;
+        }
+        struct stat st = {0};
+        if(stat(hash_path, &st) < 0) {
+            LOG_ERROR("Unable to stat %s: %s\n", hash_path, strerror(errno));
+            free(hash_path);
+            stats.io_errors++;
+            ok = false;
+            continue;
+        }
+        free(hash_path);
+        if(!S_ISDIR(st.st_mode))
+            continue;
+        if(!validate_hash_dir(chunk_dir, entry->d_name, &stats))
+            ok = false;
+    }
+
+    closedir(base_dir);
+
+    printf("Validated %llu chunk files: %llu ok, %llu zero-length",
+           (long long unsigned)stats.files,
+           (long long unsigned)stats.valid,
+           (long long unsigned)stats.zero);
+    if(stats.digest_errors)
+        printf(", %llu digest mismatches",
+               (long long unsigned)stats.digest_errors);
+    if(stats.size_errors)
+        printf(", %llu size errors",
+               (long long unsigned)stats.size_errors);
+    if(stats.name_errors)
+        printf(", %llu naming issues",
+               (long long unsigned)stats.name_errors);
+    if(stats.io_errors)
+        printf(", %llu I/O errors",
+               (long long unsigned)stats.io_errors);
+    printf("\n");
+
+    if(stats.digest_errors || stats.io_errors || stats.name_errors ||
+       stats.size_errors)
+        return 1;
+    if(!ok)
+        return 1;
+    return 0;
+}

--- a/src/zck_dl_dir.c
+++ b/src/zck_dl_dir.c
@@ -1,0 +1,362 @@
+#include <argp.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <zck.h>
+
+#include "util_common.h"
+
+static char doc[] =
+    "zckdlfs - Reconstruct a zchunk file from a local chunk directory";
+
+static char args_doc[] = "<zchunk file>";
+
+struct arguments {
+    char *args[1];
+    zck_log_type log_level;
+    char *source;
+    char *chunk_dir;
+    bool exit;
+};
+
+static struct argp_option options[] = {
+    {"verbose", 'v', 0, 0, "Increase verbosity"},
+    {"quiet", 'q', 0, 0,
+     "Only show warnings (can be specified twice to only show errors)"},
+    {"source", 's', "FILE", 0, "File to use as delta source"},
+    {"chunk-dir", 'd', "DIR", 0,
+     "Directory containing compressed chunk files"},
+    {"version", 'V', 0, 0, "Show program version"},
+    {0}
+};
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    struct arguments *arguments = state->input;
+
+    if(arguments->exit)
+        return 0;
+
+    switch(key) {
+        case 'v':
+            if(arguments->log_level > ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level--;
+            if(arguments->log_level < ZCK_LOG_DDEBUG)
+                arguments->log_level = ZCK_LOG_DDEBUG;
+            break;
+        case 'q':
+            if(arguments->log_level < ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level += 1;
+            if(arguments->log_level > ZCK_LOG_NONE)
+                arguments->log_level = ZCK_LOG_NONE;
+            break;
+        case 's':
+            arguments->source = arg;
+            break;
+        case 'd':
+            arguments->chunk_dir = arg;
+            break;
+        case 'V':
+            version();
+            arguments->exit = true;
+            break;
+        case ARGP_KEY_ARG:
+            if(state->arg_num >= 1) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            arguments->args[state->arg_num] = arg;
+            break;
+        case ARGP_KEY_END:
+            if(state->arg_num < 1) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+static char *chunk_path(const char *dir, const char *hash_name,
+                        const char *digest) {
+    size_t digest_len = strlen(digest);
+    char prefix[3] = {0};
+    if(digest_len >= 2) {
+        prefix[0] = digest[0];
+        prefix[1] = digest[1];
+    } else {
+        prefix[0] = 's';
+        prefix[1] = 'm';
+    }
+    prefix[2] = '\0';
+
+    size_t path_len = strlen(dir) + strlen(hash_name) + strlen(prefix) +
+                      strlen(digest) + strlen("///.chunk") + 1;
+    char *path = calloc(path_len, 1);
+    if(path == NULL)
+        return NULL;
+    snprintf(path, path_len, "%s/%s/%s/%s.chunk", dir, hash_name, prefix,
+             digest);
+    return path;
+}
+
+int main(int argc, char *argv[]) {
+    struct arguments arguments = {0};
+    arguments.log_level = ZCK_LOG_INFO;
+
+    int retval = argp_parse(&argp, argc, argv, 0, 0, &arguments);
+    if(retval || arguments.exit)
+        exit(retval);
+
+    if(arguments.chunk_dir == NULL) {
+        LOG_ERROR("--chunk-dir must be specified\n");
+        exit(2);
+    }
+
+    zck_set_log_level(arguments.log_level);
+
+    zckCtx *zck_src = NULL;
+    int src_fd = -1;
+    if(arguments.source) {
+        src_fd = open(arguments.source, O_RDONLY | O_BINARY);
+        if(src_fd < 0) {
+            LOG_ERROR("Unable to open %s\n", arguments.source);
+            perror(NULL);
+            exit(10);
+        }
+        zck_src = zck_create();
+        if(zck_src == NULL)
+            exit(10);
+        if(!zck_init_read(zck_src, src_fd)) {
+            LOG_ERROR("Unable to open %s: %s\n", arguments.source,
+                      zck_get_error(zck_src));
+            exit(10);
+        }
+    }
+
+    int dst_fd = open(arguments.args[0], O_RDWR | O_BINARY);
+    if(dst_fd < 0) {
+        LOG_ERROR("Unable to open %s: %s\n", arguments.args[0],
+                  strerror(errno));
+        exit(10);
+    }
+
+    zckCtx *zck_tgt = zck_create();
+    if(zck_tgt == NULL)
+        exit(10);
+    if(!zck_init_adv_read(zck_tgt, dst_fd)) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        exit(10);
+    }
+    if(!zck_read_lead(zck_tgt) || !zck_read_header(zck_tgt)) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        exit(10);
+    }
+
+    if(zck_src && !zck_copy_chunks(zck_src, zck_tgt)) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        exit(10);
+    }
+
+    int chk_ret = zck_find_valid_chunks(zck_tgt);
+    if(chk_ret == 0) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        exit(10);
+    }
+    if(chk_ret == 1) {
+        printf("Missing chunks: 0\n");
+        zck_free(&zck_tgt);
+        zck_free(&zck_src);
+        close(dst_fd);
+        return 0;
+    }
+
+    zckDL *dl = zck_dl_init(zck_tgt);
+    if(dl == NULL)
+        exit(10);
+
+    const char *hash_name =
+        zck_hash_name_from_type(zck_get_chunk_hash_type(zck_tgt));
+    if(hash_name == NULL) {
+        LOG_ERROR("Unable to determine chunk hash type\n");
+        exit(10);
+    }
+
+    ssize_t missing = zck_missing_chunks(zck_tgt);
+    if(missing < 0) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        exit(10);
+    }
+    printf("Missing chunks: %lli\n", (long long)missing);
+
+    size_t copied_bytes = 0;
+    bool error = false;
+
+    while(true) {
+        missing = zck_missing_chunks(zck_tgt);
+        if(missing < 0) {
+            LOG_ERROR("%s", zck_get_error(zck_tgt));
+            error = true;
+            break;
+        }
+        if(missing == 0)
+            break;
+
+        zckChunk *tgt_chunk = NULL;
+        for(zckChunk *chk = zck_get_first_chunk(zck_tgt); chk;
+            chk = zck_get_next_chunk(chk)) {
+            int valid = zck_get_chunk_valid(chk);
+            if(valid < 0) {
+                tgt_chunk = chk;
+                break;
+            }
+            if(valid == 0) {
+                tgt_chunk = chk;
+                break;
+            }
+        }
+        if(tgt_chunk == NULL) {
+            LOG_ERROR("Unable to locate missing chunk\n");
+            error = true;
+            break;
+        }
+
+        ssize_t comp_size = zck_get_chunk_comp_size(tgt_chunk);
+        if(comp_size < 0) {
+            LOG_ERROR("%s", zck_get_error(zck_tgt));
+            error = true;
+            break;
+        }
+
+        char *digest = zck_get_chunk_digest(tgt_chunk);
+        if(digest == NULL) {
+            LOG_ERROR("Unable to get chunk digest\n");
+            error = true;
+            break;
+        }
+
+        char *path = chunk_path(arguments.chunk_dir, hash_name, digest);
+        if(path == NULL) {
+            free(digest);
+            error = true;
+            break;
+        }
+
+        int chunk_fd = open(path, O_RDONLY | O_BINARY);
+        if(chunk_fd < 0) {
+            LOG_ERROR("Missing chunk %s in %s\n", digest, path);
+            free(path);
+            free(digest);
+            error = true;
+            break;
+        }
+
+        zck_dl_reset(dl);
+        zckRange *range = zck_get_missing_range(zck_tgt, 1);
+        if(range == NULL) {
+            LOG_ERROR("%s", zck_get_error(zck_tgt));
+            close(chunk_fd);
+            free(path);
+            free(digest);
+            error = true;
+            break;
+        }
+        if(!zck_dl_set_range(dl, range)) {
+            LOG_ERROR("%s", zck_get_error(zck_tgt));
+            zck_range_free(&range);
+            close(chunk_fd);
+            free(path);
+            free(digest);
+            error = true;
+            break;
+        }
+
+        ssize_t remaining = comp_size;
+        char buffer[BUF_SIZE];
+        bool chunk_ok = true;
+        while(remaining > 0) {
+            ssize_t to_read = remaining > (ssize_t)sizeof(buffer)
+                                  ? (ssize_t)sizeof(buffer)
+                                  : remaining;
+            ssize_t rb = read(chunk_fd, buffer, (size_t)to_read);
+            if(rb <= 0) {
+                LOG_ERROR("Error reading %s: %s\n", path, strerror(errno));
+                chunk_ok = false;
+                break;
+            }
+            size_t wb = zck_write_chunk_cb(buffer, 1, (size_t)rb, dl);
+            if(wb != (size_t)rb) {
+                LOG_ERROR("Failed to import chunk %s\n", digest);
+                chunk_ok = false;
+                break;
+            }
+            remaining -= rb;
+        }
+
+        if(!zck_dl_set_range(dl, NULL)) {
+            LOG_ERROR("%s", zck_get_error(zck_tgt));
+            zck_range_free(&range);
+            close(chunk_fd);
+            free(path);
+            free(digest);
+            error = true;
+            break;
+        }
+        zck_range_free(&range);
+        close(chunk_fd);
+
+        if(!chunk_ok || remaining > 0) {
+            free(path);
+            free(digest);
+            error = true;
+            break;
+        }
+
+        copied_bytes += (size_t)comp_size;
+        free(path);
+        free(digest);
+    }
+
+    if(!error) {
+        if(ftruncate(dst_fd, zck_get_length(zck_tgt)) < 0) {
+            perror(NULL);
+            error = true;
+        }
+    }
+
+    if(!error) {
+        int valid = zck_validate_data_checksum(zck_tgt);
+        if(valid < 1) {
+            if(valid == -1)
+                LOG_ERROR("Data checksum failed verification\n");
+            else
+                LOG_ERROR("%s", zck_get_error(zck_tgt));
+            error = true;
+        }
+    }
+
+    if(!error) {
+        printf("Copied %llu bytes from %s\n",
+               (long long unsigned)copied_bytes, arguments.chunk_dir);
+    }
+
+    zck_dl_free(&dl);
+    zck_free(&zck_tgt);
+    zck_free(&zck_src);
+    if(src_fd >= 0)
+        close(src_fd);
+    close(dst_fd);
+
+    return error ? 1 : 0;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -116,6 +116,13 @@ test(
     ]
 )
 test(
+    'check version info in zck_chunk_validate',
+    zck_chunk_validate,
+    args: [
+        '-V'
+    ]
+)
+test(
     'check version info in zckdlfs',
     zckdlfs,
     args: [

--- a/test/meson.build
+++ b/test/meson.build
@@ -108,6 +108,20 @@ test(
         '-V'
     ]
 )
+test(
+    'check version info in zck_chunk_store',
+    zck_chunk_store,
+    args: [
+        '-V'
+    ]
+)
+test(
+    'check version info in zckdlfs',
+    zckdlfs,
+    args: [
+        '-V'
+    ]
+)
 
 test(
     'check opening file with optional flags',


### PR DESCRIPTION
## Summary
- add the `zckdlfs` utility that rebuilds a zchunk file from a local chunk directory instead of using HTTP ranges
- add the `zck_chunk_store` helper for exporting compressed chunks into the directory layout consumed by `zckdlfs`
- document the new workflow and hook both tools into the build, test, and man-page installation targets

## Testing
- `ninja -C build`
- `ninja -C build test`


------
https://chatgpt.com/codex/tasks/task_e_68cdb2241dd8832ea4928704f4578d9f