### PR TITLE
Add offline chunk cache tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ To download a zchunk file, run:
 zckdl -s <source> <url of target>
 ```
 
+To export compressed chunks into a reusable cache, run:
+```
+zck_chunk_store <chunk-dir> <file.zck> [file.zck ...]
+```
+
+To rebuild a zchunk file from a cache of chunks, run:
+```
+zckdir --chunk-dir <chunk-dir> --header <header-file> <output.zck>
+```
+
 To read a zchunk header, run:
 ```
 zck_read_header <file>
@@ -90,6 +100,7 @@ your system.
 - [Format definition](zchunk_format.txt)
 - [Initial announcement](https://www.jdieter.net/posts/2018/04/30/introducing-zchunk)
 - [How zchunk works (with pretty pictures)](https://www.jdieter.net/posts/2018/05/31/what-is-zchunk)
+- [Offline chunk workflow](doc/offline-updates.md)
 
 
 ## License

--- a/doc/offline-updates.md
+++ b/doc/offline-updates.md
@@ -1,0 +1,64 @@
+# Offline updates with zck_chunk_store and zckdir
+
+The `zck_chunk_store` utility exports the compressed chunks from one or more
+`.zck` files into a filesystem cache. `zckdir` consumes that cache to rebuild a
+`.zck` file without fetching data from an HTTP server.
+
+## Chunk cache layout
+
+Running `zck_chunk_store /path/to/cache file.zck` creates the following
+structure:
+
+```
+/path/to/cache/
+├── headers/
+│   └── file.zck.header        # lead + header bytes to seed clients
+├── meta.conf                  # chunk hash metadata
+└── chunks/
+    └── <hash-name>/
+        ├── <hh>/<digest>.chunk
+        └── ...
+```
+
+* `meta.conf` records the chunk hash algorithm and digest size used by the
+  cached files. `zckdir` refuses to use a cache whose metadata does not match
+  the target file.
+* `headers/` contains byte-for-byte copies of the lead and header for each
+  exported `.zck` file. Copy one of these header files to the destination path
+  before invoking `zckdir`, or pass it via `--header` and let the tool copy it
+  for you.
+* Chunk data files live under `chunks/<hash-name>/<hh>/<digest>.chunk`, where
+  `<hash-name>` is the chunk hash name (e.g. `sha512_128`), `<hh>` is the first
+  two hex characters of the digest, and the filename is the full digest. If a
+  chunk has a compressed digest of all zeros the uncompressed digest is used and
+  the chunk is stored under `chunks-uncompressed/<hash-name>/...` instead.
+
+Re-running `zck_chunk_store` against additional `.zck` files deduplicates
+matching chunks automatically because the digest-based filenames collide.
+
+## Populating removable media
+
+To prepare a cache for transfer:
+
+```bash
+$ mkdir -p /srv/zck-cache
+$ zck_chunk_store /srv/zck-cache path/to/a.zck path/to/b.zck
+$ rsync -av /srv/zck-cache/ /media/usb/zck-cache/
+```
+
+Only the subset of `*.chunk` files that are missing on the client side need to
+be copied to removable media for subsequent updates.
+
+## Rebuilding a file offline
+
+1. Copy the matching header file to the target path (or rely on `--header`).
+2. Mount or copy the cache directory to the client.
+3. Run `zckdir --chunk-dir /media/usb/zck-cache --header /media/usb/zck-cache/headers/file.zck.header file.zck`.
+
+`zckdir` validates any existing data, copies matching chunks from a local source
+file when `--source` is provided, and imports chunk files from the cache. When
+all chunks are present it truncates the output to the expected length and
+verifies the overall checksum.
+
+If some digests are still missing, `zckdir` lists them so that the operator can
+transfer only the required `*.chunk` files during the next update cycle.

--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -346,6 +346,16 @@ const ZCK_PUBLIC_API char *zck_hash_name_from_type(int hash_type)
 /* Get any matching chunks from src and put them in the right place in tgt */
 bool ZCK_PUBLIC_API zck_copy_chunks(zckCtx *src, zckCtx *tgt)
     ZCK_WARN_UNUSED;
+/* Overwrite chunk location with zeros */
+bool ZCK_PUBLIC_API zck_zero_chunk(zckCtx *tgt, zckChunk *chunk)
+    ZCK_WARN_UNUSED;
+/* Import chunk contents from an open file descriptor */
+bool ZCK_PUBLIC_API zck_import_chunk_from_fd(zckCtx *tgt, zckChunk *chunk, int fd)
+    ZCK_WARN_UNUSED;
+/* Import chunk contents from a file path */
+bool ZCK_PUBLIC_API zck_import_chunk_from_path(zckCtx *tgt, zckChunk *chunk,
+                                              const char *path)
+    ZCK_WARN_UNUSED;
 /* Free zckRange */
 void ZCK_PUBLIC_API zck_range_free(zckRange **info);
 /* Get range string from start and end location */

--- a/src/lib/dl/dl.c
+++ b/src/lib/dl/dl.c
@@ -30,8 +30,14 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <errno.h>
 #include <zck.h>
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
 
 #include "zck_private.h"
 
@@ -58,7 +64,7 @@ static void clear_dl_regex(zckDL *dl) {
 }
 
 /* Write zeros to tgt->fd in location of tgt_idx */
-static bool zero_chunk(zckCtx *tgt, zckChunk *tgt_idx) {
+bool ZCK_PUBLIC_API zck_zero_chunk(zckCtx *tgt, zckChunk *tgt_idx) {
     char buf[BUF_SIZE] = {0};
     size_t to_read = tgt_idx->comp_length;
     if(!seek_data(tgt, tgt->data_offset + tgt_idx->start, SEEK_SET))
@@ -81,7 +87,7 @@ static bool set_chunk_valid(zckDL *dl) {
 
     int retval = validate_chunk(dl->tgt_check, ZCK_LOG_WARNING);
     if(retval < 1) {
-        if(!zero_chunk(dl->zck, dl->tgt_check))
+        if(!zck_zero_chunk(dl->zck, dl->tgt_check))
             return false;
         dl->tgt_check->valid = -1;
         return false;
@@ -153,7 +159,7 @@ static bool write_and_verify_chunk(zckCtx *src, zckCtx *tgt,
         pdigest = get_digest_string(digest, src_idx->digest_size);
         zck_log(ZCK_LOG_INFO, "Target hash: %s", pdigest);
         free(pdigest);
-        if(!zero_chunk(tgt, tgt_idx))
+        if(!zck_zero_chunk(tgt, tgt_idx))
             return false;
         tgt_idx->valid = -1;
     } else {
@@ -165,6 +171,109 @@ static bool write_and_verify_chunk(zckCtx *src, zckCtx *tgt,
     }
     free(digest);
     return true;
+}
+
+bool ZCK_PUBLIC_API zck_import_chunk_from_fd(zckCtx *tgt, zckChunk *tgt_idx,
+                                             int fd) {
+    VALIDATE_BOOL(tgt);
+
+    if(tgt_idx == NULL) {
+        set_error(tgt, "Invalid chunk reference");
+        return false;
+    }
+    if(fd < 0) {
+        set_error(tgt, "Invalid chunk file descriptor");
+        return false;
+    }
+
+    struct stat st = {0};
+    if(fstat(fd, &st) < 0) {
+        set_error(tgt, "Unable to stat chunk file: %s", strerror(errno));
+        return false;
+    }
+    if((size_t)st.st_size != tgt_idx->comp_length) {
+        set_error(tgt,
+                  "Chunk size mismatch (expected %llu, got %llu)",
+                  (long long unsigned) tgt_idx->comp_length,
+                  (long long unsigned) st.st_size);
+        return false;
+    }
+    if(lseek(fd, 0, SEEK_SET) < 0) {
+        set_error(tgt, "Unable to seek chunk file: %s", strerror(errno));
+        return false;
+    }
+    if(!seek_data(tgt, tgt->data_offset + tgt_idx->start, SEEK_SET))
+        return false;
+
+    zckHash check_hash = {0};
+    if(!hash_init(tgt, &check_hash, &(tgt->chunk_hash_type)))
+        return false;
+
+    static char buf[BUF_SIZE] = {0};
+    size_t to_read = tgt_idx->comp_length;
+    while(to_read > 0) {
+        size_t rb = BUF_SIZE;
+        if(rb > to_read)
+            rb = to_read;
+        ssize_t read_bytes = read(fd, buf, rb);
+        if(read_bytes < 0) {
+            set_error(tgt, "Unable to read chunk data: %s", strerror(errno));
+            return false;
+        }
+        if((size_t)read_bytes != rb) {
+            set_error(tgt, "Short read when importing chunk data");
+            return false;
+        }
+        if(!hash_update(tgt, &check_hash, buf, rb))
+            return false;
+        if(!write_data(tgt, tgt->fd, buf, rb))
+            return false;
+        to_read -= rb;
+    }
+    char *digest = hash_finalize(tgt, &check_hash);
+    bool success = false;
+    if(digest) {
+        if(memcmp(digest, tgt_idx->digest, tgt_idx->digest_size) != 0) {
+            char *pdigest = zck_get_chunk_digest(tgt_idx);
+            zck_log(ZCK_LOG_INFO,
+                    "Chunk imported from file has wrong digest, expected %s",
+                    pdigest ? pdigest : "<unknown>");
+            free(pdigest);
+            pdigest = get_digest_string(digest, tgt_idx->digest_size);
+            zck_log(ZCK_LOG_INFO, "Chunk file digest: %s",
+                    pdigest ? pdigest : "<unknown>");
+            free(pdigest);
+            if(!zck_zero_chunk(tgt, tgt_idx)) {
+                free(digest);
+                return false;
+            }
+            tgt_idx->valid = -1;
+        } else {
+            tgt_idx->valid = 1;
+            success = true;
+        }
+    }
+    free(digest);
+    return success;
+}
+
+bool ZCK_PUBLIC_API zck_import_chunk_from_path(zckCtx *tgt, zckChunk *tgt_idx,
+                                               const char *path) {
+    VALIDATE_BOOL(tgt);
+
+    if(tgt_idx == NULL || path == NULL) {
+        set_error(tgt, "Invalid chunk import arguments");
+        return false;
+    }
+
+    int fd = open(path, O_RDONLY | O_BINARY);
+    if(fd < 0) {
+        set_error(tgt, "Unable to open chunk file %s: %s", path, strerror(errno));
+        return false;
+    }
+    bool success = zck_import_chunk_from_fd(tgt, tgt_idx, fd);
+    close(fd);
+    return success;
 }
 
 /* Split current read into the appropriate chunks and write appropriately */

--- a/src/meson.build
+++ b/src/meson.build
@@ -64,3 +64,21 @@ zckdl = executable(
     install: true,
     c_args: preprocessor_defines
 )
+zck_chunk_store = executable(
+    'zck_chunk_store',
+    ['zck_chunk_store.c', 'util_common.c'] + extra_win_src,
+    include_directories: inc,
+    dependencies: argplib,
+    link_with: zcklib,
+    install: true,
+    c_args: preprocessor_defines
+)
+zckdir = executable(
+    'zckdir',
+    ['zck_dir.c', 'util_common.c'] + extra_win_src,
+    include_directories: inc,
+    dependencies: argplib,
+    link_with: zcklib,
+    install: true,
+    c_args: preprocessor_defines
+)

--- a/src/zck_chunk_store.c
+++ b/src/zck_chunk_store.c
@@ -1,0 +1,496 @@
+/*
+ * Offline chunk store generator for zchunk files.
+ */
+
+#define _GNU_SOURCE
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <argp.h>
+#include <zck.h>
+
+#include "util_common.h"
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+static char doc[] = "zck_chunk_store - Export compressed chunks into a directory cache";
+
+static char args_doc[] = "<chunk-dir> <file> [file...]";
+
+static struct argp_option options[] = {
+    {"verbose",        'v',  0, 0, "Increase verbosity"},
+    {"quiet",          'q',  0, 0,
+     "Only show warnings (can be specified twice to only show errors)"},
+    {"force",          'f',  0, 0, "Overwrite existing chunk files"},
+    {"version",        'V',  0, 0, "Show program version"},
+    { 0 }
+};
+
+struct arguments {
+    char *chunk_dir;
+    char **inputs;
+    size_t input_count;
+    size_t input_alloc;
+    zck_log_type log_level;
+    bool force;
+    bool exit;
+};
+
+static bool ensure_dir(const char *path) {
+    struct stat st = {0};
+    if(stat(path, &st) == 0) {
+        if(S_ISDIR(st.st_mode))
+            return true;
+        fprintf(stderr, "%s exists and is not a directory\n", path);
+        return false;
+    }
+    if(errno != ENOENT) {
+        perror(path);
+        return false;
+    }
+    if(mkdir(path, 0777) < 0) {
+        if(errno == EEXIST)
+            return true;
+        perror(path);
+        return false;
+    }
+    return true;
+}
+
+static const char *path_basename(const char *path) {
+    const char *slash = strrchr(path, '/');
+#ifdef _WIN32
+    const char *bslash = strrchr(path, '\\');
+    if(bslash && (!slash || bslash > slash))
+        slash = bslash;
+#endif
+    if(!slash)
+        return path;
+    return slash + 1;
+}
+
+static bool write_all(int fd, const char *buf, size_t length) {
+    while(length > 0) {
+        ssize_t written = write(fd, buf, length);
+        if(written < 0) {
+            return false;
+        }
+        buf += written;
+        length -= written;
+    }
+    return true;
+}
+
+static bool read_exact(int fd, char *buf, size_t length) {
+    while(length > 0) {
+        ssize_t rb = read(fd, buf, length);
+        if(rb < 0)
+            return false;
+        if(rb == 0)
+            return false;
+        buf += rb;
+        length -= rb;
+    }
+    return true;
+}
+
+static bool read_meta(const char *path, char *hash_name, size_t hash_len,
+                      ssize_t *digest_size) {
+    FILE *fp = fopen(path, "r");
+    if(!fp)
+        return false;
+
+    char line[256];
+    while(fgets(line, sizeof(line), fp)) {
+        if(strncmp(line, "chunk_hash=", 11) == 0) {
+            strncpy(hash_name, line + 11, hash_len - 1);
+            hash_name[hash_len-1] = '\0';
+            char *nl = strchr(hash_name, '\n');
+            if(nl)
+                *nl = '\0';
+        } else if(strncmp(line, "chunk_digest_size=", 19) == 0) {
+            *digest_size = strtol(line + 19, NULL, 10);
+        }
+    }
+    fclose(fp);
+    return hash_name[0] != '\0' && *digest_size >= 0;
+}
+
+static bool write_meta(const char *dir, zckCtx *zck, bool force) {
+    const char *hash_name = zck_hash_name_from_type(zck_get_chunk_hash_type(zck));
+    ssize_t digest_size = zck_get_chunk_digest_size(zck);
+
+    char meta_path[PATH_MAX];
+    snprintf(meta_path, sizeof(meta_path), "%s/meta.conf", dir);
+
+    char existing_hash[128] = {0};
+    ssize_t existing_digest = -1;
+    if(read_meta(meta_path, existing_hash, sizeof(existing_hash), &existing_digest)) {
+        if(strcmp(existing_hash, hash_name) != 0 || existing_digest != digest_size) {
+            fprintf(stderr,
+                    "Existing metadata in %s is incompatible with %s\n",
+                    meta_path, hash_name);
+            return false;
+        }
+        if(!force)
+            return true;
+    }
+
+    FILE *fp = fopen(meta_path, "w");
+    if(!fp) {
+        perror(meta_path);
+        return false;
+    }
+    fprintf(fp, "chunk_hash=%s\n", hash_name);
+    fprintf(fp, "chunk_digest_size=%lli\n", (long long)digest_size);
+    fclose(fp);
+    return true;
+}
+
+static bool export_header(zckCtx *zck, const char *chunk_dir, const char *input) {
+    ssize_t header_len = zck_get_header_length(zck);
+    if(header_len <= 0) {
+        fprintf(stderr, "Unable to determine header length for %s\n", input);
+        return false;
+    }
+
+    size_t header_size = (size_t)header_len;
+    int fd = zck_get_fd(zck);
+    if(lseek(fd, 0, SEEK_SET) < 0) {
+        perror("lseek");
+        return false;
+    }
+
+    char *buffer = malloc(header_size);
+    if(!buffer) {
+        fprintf(stderr, "Unable to allocate %lli bytes for header\n",
+                (long long)header_len);
+        return false;
+    }
+
+    if(!read_exact(fd, buffer, header_size)) {
+        fprintf(stderr, "Short read when exporting header for %s\n", input);
+        free(buffer);
+        return false;
+    }
+    if(lseek(fd, 0, SEEK_SET) < 0) {
+        perror("lseek");
+        free(buffer);
+        return false;
+    }
+
+    char headers_dir[PATH_MAX];
+    snprintf(headers_dir, sizeof(headers_dir), "%s/headers", chunk_dir);
+    if(!ensure_dir(headers_dir)) {
+        free(buffer);
+        return false;
+    }
+
+    const char *base = path_basename(input);
+    char header_path[PATH_MAX];
+    size_t dir_len = strlen(headers_dir);
+    size_t base_len = strlen(base);
+    const char suffix[] = ".header";
+    if(dir_len + 1 + base_len + sizeof(suffix) > sizeof(header_path)) {
+        fprintf(stderr, "Header path for %s is too long\n", input);
+        free(buffer);
+        return false;
+    }
+    memcpy(header_path, headers_dir, dir_len);
+    header_path[dir_len] = '/';
+    memcpy(header_path + dir_len + 1, base, base_len);
+    memcpy(header_path + dir_len + 1 + base_len, suffix, sizeof(suffix));
+
+    int out_fd = open(header_path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
+    if(out_fd < 0) {
+        perror(header_path);
+        free(buffer);
+        return false;
+    }
+    bool ok = write_all(out_fd, buffer, header_size);
+    close(out_fd);
+    free(buffer);
+    if(!ok) {
+        fprintf(stderr, "Unable to write header to %s\n", header_path);
+        return false;
+    }
+    return true;
+}
+
+static bool digest_all_zero(const char *digest) {
+    if(!digest)
+        return false;
+    for(const char *c = digest; *c; c++)
+        if(*c != '0')
+            return false;
+    return true;
+}
+
+static void hash_to_dir_name(const char *hash_name, char *dst, size_t dst_len) {
+    size_t j = 0;
+    for(size_t i = 0; hash_name[i] && j + 1 < dst_len; i++) {
+        unsigned char c = (unsigned char)hash_name[i];
+        if(isalnum(c))
+            dst[j++] = tolower(c);
+        else
+            dst[j++] = '_';
+    }
+    dst[j] = '\0';
+}
+
+static bool ensure_chunk_subdir(const char *chunk_dir, const char *hash_name,
+                                const char *prefix, bool uncompressed) {
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "%s/%s", chunk_dir,
+             uncompressed ? "chunks-uncompressed" : "chunks");
+    if(!ensure_dir(path))
+        return false;
+    snprintf(path, sizeof(path), "%s/%s/%s", chunk_dir,
+             uncompressed ? "chunks-uncompressed" : "chunks", hash_name);
+    if(!ensure_dir(path))
+        return false;
+    snprintf(path, sizeof(path), "%s/%s/%s/%c%c", chunk_dir,
+             uncompressed ? "chunks-uncompressed" : "chunks", hash_name,
+             prefix[0], prefix[1]);
+    return ensure_dir(path);
+}
+
+static bool write_chunk_file(const char *chunk_dir, const char *hash_name,
+                             const char *digest, const char *data,
+                             size_t data_len, bool uncompressed, bool force) {
+    char dir_path[PATH_MAX];
+    snprintf(dir_path, sizeof(dir_path), "%s/%s/%s/%c%c", chunk_dir,
+             uncompressed ? "chunks-uncompressed" : "chunks", hash_name,
+             digest[0], digest[1]);
+    if(!ensure_dir(dir_path))
+        return false;
+
+    char file_path[PATH_MAX];
+    snprintf(file_path, sizeof(file_path), "%s/%s/%s/%c%c/%s.chunk", chunk_dir,
+             uncompressed ? "chunks-uncompressed" : "chunks", hash_name,
+             digest[0], digest[1], digest);
+
+    int flags = O_WRONLY | O_CREAT | O_BINARY;
+    if(force)
+        flags |= O_TRUNC;
+    else
+        flags |= O_EXCL;
+
+    int fd = open(file_path, flags, 0644);
+    if(fd < 0) {
+        if(errno == EEXIST && !force)
+            return true;
+        perror(file_path);
+        return false;
+    }
+
+    bool ok = true;
+    if(data_len > 0)
+        ok = write_all(fd, data, data_len);
+    close(fd);
+    if(!ok) {
+        fprintf(stderr, "Unable to write %s\n", file_path);
+        return false;
+    }
+    return true;
+}
+
+static bool export_chunks(zckCtx *zck, const char *chunk_dir, bool force) {
+    const char *hash_name = zck_hash_name_from_type(zck_get_chunk_hash_type(zck));
+    char hash_dir[128];
+    hash_to_dir_name(hash_name, hash_dir, sizeof(hash_dir));
+    ssize_t chunk_count = zck_get_chunk_count(zck);
+    if(chunk_count < 0)
+        return false;
+
+    for(ssize_t i = 0; i < chunk_count; i++) {
+        zckChunk *chunk = zck_get_chunk(zck, i);
+        if(!chunk) {
+            fprintf(stderr, "Unable to read chunk %lli\n", (long long)i);
+            return false;
+        }
+        ssize_t comp_len = zck_get_chunk_comp_size(chunk);
+        if(comp_len < 0)
+            return false;
+        if(comp_len == 0)
+            continue;
+        char *digest = zck_get_chunk_digest(chunk);
+        bool uncompressed = false;
+        if(!digest) {
+            fprintf(stderr, "Unable to read chunk digest\n");
+            return false;
+        }
+        if(digest_all_zero(digest)) {
+            free(digest);
+            digest = zck_get_chunk_digest_uncompressed(chunk);
+            uncompressed = true;
+            if(!digest) {
+                fprintf(stderr, "Chunk missing digest\n");
+                return false;
+            }
+        }
+
+        if(strlen(digest) < 2) {
+            fprintf(stderr, "Digest too short\n");
+            free(digest);
+            return false;
+        }
+        if(!ensure_chunk_subdir(chunk_dir, hash_dir, digest, uncompressed)) {
+            free(digest);
+            return false;
+        }
+
+        size_t comp_size = (size_t)comp_len;
+        char *buffer = malloc(comp_size);
+        if(!buffer) {
+            fprintf(stderr,
+                    "Unable to allocate %lli bytes for chunk export\n",
+                    (long long)comp_len);
+            free(digest);
+            return false;
+        }
+        ssize_t read_len = zck_get_chunk_comp_data(chunk, buffer, comp_size);
+        if(read_len != (ssize_t)comp_size) {
+            fprintf(stderr, "Short read exporting chunk\n");
+            free(buffer);
+            free(digest);
+            return false;
+        }
+        bool ok = write_chunk_file(chunk_dir, hash_dir, digest, buffer, comp_size,
+                                   uncompressed, force);
+        free(buffer);
+        free(digest);
+        if(!ok)
+            return false;
+    }
+    return true;
+}
+
+static error_t parse_opt (int key, char *arg, struct argp_state *state) {
+    struct arguments *arguments = state->input;
+
+    if(arguments->exit)
+        return 0;
+
+    switch (key) {
+        case 'v':
+            if(arguments->log_level > ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level--;
+            if(arguments->log_level < ZCK_LOG_DDEBUG)
+                arguments->log_level = ZCK_LOG_DDEBUG;
+            break;
+        case 'q':
+            if(arguments->log_level < ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level += 1;
+            if(arguments->log_level > ZCK_LOG_NONE)
+                arguments->log_level = ZCK_LOG_NONE;
+            break;
+        case 'f':
+            arguments->force = true;
+            break;
+        case 'V':
+            version();
+            arguments->exit = true;
+            break;
+        case ARGP_KEY_ARG:
+            if (state->arg_num == 0) {
+                arguments->chunk_dir = arg;
+            } else {
+                if(arguments->input_count + 1 >= arguments->input_alloc) {
+                    size_t new_alloc = arguments->input_alloc ?
+                                       arguments->input_alloc * 2 : 4;
+                    char **tmp = realloc(arguments->inputs,
+                                         new_alloc * sizeof(char*));
+                    if(!tmp)
+                        return ENOMEM;
+                    arguments->inputs = tmp;
+                    arguments->input_alloc = new_alloc;
+                }
+                arguments->inputs[arguments->input_count++] = arg;
+            }
+            break;
+        case ARGP_KEY_END:
+            if(!arguments->chunk_dir || arguments->input_count == 0) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+int main(int argc, char **argv) {
+    struct arguments arguments = {0};
+    arguments.log_level = ZCK_LOG_ERROR;
+
+    int retval = argp_parse(&argp, argc, argv, 0, 0, &arguments);
+    if(retval || arguments.exit)
+        exit(retval);
+
+    zck_set_log_level(arguments.log_level);
+
+    if(!ensure_dir(arguments.chunk_dir))
+        exit(1);
+
+    for(size_t i = 0; i < arguments.input_count; i++) {
+        const char *input = arguments.inputs[i];
+        int fd = open(input, O_RDONLY | O_BINARY);
+        if(fd < 0) {
+            perror(input);
+            exit(1);
+        }
+
+        zckCtx *zck = zck_create();
+        if(!zck) {
+            close(fd);
+            exit(1);
+        }
+        if(!zck_init_read(zck, fd)) {
+            LOG_ERROR("Unable to open %s: %s", input, zck_get_error(zck));
+            zck_free(&zck);
+            close(fd);
+            exit(1);
+        }
+
+        if(!write_meta(arguments.chunk_dir, zck, arguments.force)) {
+            zck_free(&zck);
+            close(fd);
+            exit(1);
+        }
+        if(!export_header(zck, arguments.chunk_dir, input)) {
+            zck_free(&zck);
+            close(fd);
+            exit(1);
+        }
+        if(!export_chunks(zck, arguments.chunk_dir, arguments.force)) {
+            zck_free(&zck);
+            close(fd);
+            exit(1);
+        }
+
+        zck_free(&zck);
+        close(fd);
+    }
+
+    free(arguments.inputs);
+    return 0;
+}

--- a/src/zck_dir.c
+++ b/src/zck_dir.c
@@ -1,0 +1,488 @@
+/*
+ * Offline chunk applier for zchunk files.
+ */
+
+#define _GNU_SOURCE
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <argp.h>
+#include <zck.h>
+
+#include "util_common.h"
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+static char doc[] = "zckdir - Rebuild a zchunk file using cached chunks";
+
+static char args_doc[] = "<output-file>";
+
+static struct argp_option options[] = {
+    {"verbose",    'v',  0, 0, "Increase verbosity"},
+    {"quiet",      'q',  0, 0,
+     "Only show warnings (can be specified twice to only show errors)"},
+    {"source",     's', "FILE", 0, "File to use as delta source"},
+    {"chunk-dir",  'C', "DIR", 0, "Directory containing cached chunks"},
+    {"header",     'H', "FILE", 0, "Header file to seed the output"},
+    {"version",    'V',  0, 0, "Show program version"},
+    { 0 }
+};
+
+struct missing_entry {
+    char *digest;
+    bool uncompressed;
+};
+
+struct arguments {
+    char *output;
+    char *chunk_dir;
+    char *source;
+    char *header;
+    struct missing_entry *missing;
+    size_t missing_count;
+    size_t missing_alloc;
+    zck_log_type log_level;
+    bool exit;
+};
+
+static bool write_all(int fd, const char *buf, size_t length) {
+    while(length > 0) {
+        ssize_t written = write(fd, buf, length);
+        if(written < 0)
+            return false;
+        buf += written;
+        length -= written;
+    }
+    return true;
+}
+
+static bool copy_file(const char *src, const char *dst) {
+    int in_fd = open(src, O_RDONLY | O_BINARY);
+    if(in_fd < 0) {
+        perror(src);
+        return false;
+    }
+    int out_fd = open(dst, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0666);
+    if(out_fd < 0) {
+        perror(dst);
+        close(in_fd);
+        return false;
+    }
+
+    char buf[BUF_SIZE];
+    bool ok = true;
+    for(;;) {
+        ssize_t rb = read(in_fd, buf, sizeof(buf));
+        if(rb < 0) {
+            perror(src);
+            ok = false;
+            break;
+        }
+        if(rb == 0)
+            break;
+        if(!write_all(out_fd, buf, rb)) {
+            perror(dst);
+            ok = false;
+            break;
+        }
+    }
+    close(in_fd);
+    close(out_fd);
+    return ok;
+}
+
+static bool digest_all_zero(const char *digest) {
+    if(!digest)
+        return false;
+    for(const char *c = digest; *c; c++)
+        if(*c != '0')
+            return false;
+    return true;
+}
+
+static void hash_to_dir_name(const char *hash_name, char *dst, size_t dst_len) {
+    size_t j = 0;
+    for(size_t i = 0; hash_name[i] && j + 1 < dst_len; i++) {
+        unsigned char c = (unsigned char)hash_name[i];
+        if(isalnum(c))
+            dst[j++] = tolower(c);
+        else
+            dst[j++] = '_';
+    }
+    dst[j] = '\0';
+}
+
+static bool ensure_meta(const char *chunk_dir, zckCtx *zck) {
+    char meta_path[PATH_MAX];
+    snprintf(meta_path, sizeof(meta_path), "%s/meta.conf", chunk_dir);
+    FILE *fp = fopen(meta_path, "r");
+    if(!fp) {
+        fprintf(stderr, "Unable to open %s\n", meta_path);
+        return false;
+    }
+    char expected_hash[128] = {0};
+    ssize_t expected_size = -1;
+    char line[256];
+    while(fgets(line, sizeof(line), fp)) {
+        if(strncmp(line, "chunk_hash=", 11) == 0) {
+            strncpy(expected_hash, line + 11, sizeof(expected_hash)-1);
+            char *nl = strchr(expected_hash, '\n');
+            if(nl)
+                *nl = '\0';
+        } else if(strncmp(line, "chunk_digest_size=", 18) == 0) {
+            expected_size = strtol(line + 18, NULL, 10);
+        }
+    }
+    fclose(fp);
+
+    const char *hash_name = zck_hash_name_from_type(zck_get_chunk_hash_type(zck));
+    ssize_t digest_size = zck_get_chunk_digest_size(zck);
+    if(expected_hash[0] == '\0' || expected_size < 0) {
+        fprintf(stderr, "Chunk store metadata in %s is incomplete (hash='%s', size=%lli)\n",
+                meta_path, expected_hash, (long long)expected_size);
+        return false;
+    }
+    if(strcmp(expected_hash, hash_name) != 0 || expected_size != digest_size) {
+        fprintf(stderr, "Chunk store metadata (%s/%lli) doesn't match target (%s/%lli)\n",
+                expected_hash, (long long)expected_size,
+                hash_name, (long long)digest_size);
+        return false;
+    }
+    return true;
+}
+
+static bool build_chunk_path(char *dst, size_t dst_len, const char *chunk_dir,
+                             const char *hash_name, const char *digest,
+                             bool uncompressed) {
+    if(strlen(digest) < 2)
+        return false;
+    int needed = snprintf(dst, dst_len, "%s/%s/%s/%c%c/%s.chunk",
+                          chunk_dir,
+                          uncompressed ? "chunks-uncompressed" : "chunks",
+                          hash_name, digest[0], digest[1], digest);
+    return needed > 0 && (size_t)needed < dst_len;
+}
+
+static bool add_missing(struct arguments *arguments, const char *digest,
+                        bool uncompressed) {
+    if(arguments->missing_count + 1 >= arguments->missing_alloc) {
+        size_t new_alloc = arguments->missing_alloc ?
+                           arguments->missing_alloc * 2 : 8;
+        struct missing_entry *tmp = realloc(arguments->missing,
+                                            new_alloc * sizeof(*tmp));
+        if(!tmp)
+            return false;
+        arguments->missing = tmp;
+        arguments->missing_alloc = new_alloc;
+    }
+    arguments->missing[arguments->missing_count].digest = strdup(digest);
+    if(!arguments->missing[arguments->missing_count].digest)
+        return false;
+    arguments->missing[arguments->missing_count].uncompressed = uncompressed;
+    arguments->missing_count++;
+    return true;
+}
+
+static error_t parse_opt (int key, char *arg, struct argp_state *state) {
+    struct arguments *arguments = state->input;
+
+    if(arguments->exit)
+        return 0;
+
+    switch (key) {
+        case 'v':
+            if(arguments->log_level > ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level--;
+            if(arguments->log_level < ZCK_LOG_DDEBUG)
+                arguments->log_level = ZCK_LOG_DDEBUG;
+            break;
+        case 'q':
+            if(arguments->log_level < ZCK_LOG_INFO)
+                arguments->log_level = ZCK_LOG_INFO;
+            arguments->log_level += 1;
+            if(arguments->log_level > ZCK_LOG_NONE)
+                arguments->log_level = ZCK_LOG_NONE;
+            break;
+        case 's':
+            arguments->source = arg;
+            break;
+        case 'C':
+            arguments->chunk_dir = arg;
+            break;
+        case 'H':
+            arguments->header = arg;
+            break;
+        case 'V':
+            version();
+            arguments->exit = true;
+            break;
+        case ARGP_KEY_ARG:
+            if(state->arg_num > 0) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            arguments->output = arg;
+            break;
+        case ARGP_KEY_END:
+            if(!arguments->chunk_dir || !arguments->output) {
+                argp_usage(state);
+                return EINVAL;
+            }
+            break;
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+int main(int argc, char **argv) {
+    struct arguments arguments = {0};
+    arguments.log_level = ZCK_LOG_ERROR;
+
+    int retval = argp_parse(&argp, argc, argv, 0, 0, &arguments);
+    if(retval || arguments.exit)
+        exit(retval);
+
+    zck_set_log_level(arguments.log_level);
+
+    if(arguments.header) {
+        if(!copy_file(arguments.header, arguments.output))
+            exit(1);
+    }
+
+    int dst_fd = open(arguments.output, O_RDWR | O_BINARY);
+    if(dst_fd < 0) {
+        perror(arguments.output);
+        exit(1);
+    }
+
+    zckCtx *zck_tgt = zck_create();
+    if(!zck_tgt) {
+        close(dst_fd);
+        exit(1);
+    }
+    if(!zck_init_adv_read(zck_tgt, dst_fd)) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        zck_free(&zck_tgt);
+        close(dst_fd);
+        exit(1);
+    }
+    if(!zck_read_lead(zck_tgt) || !zck_read_header(zck_tgt)) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        zck_free(&zck_tgt);
+        close(dst_fd);
+        exit(1);
+    }
+
+    if(!ensure_meta(arguments.chunk_dir, zck_tgt)) {
+        zck_free(&zck_tgt);
+        close(dst_fd);
+        exit(1);
+    }
+
+    zckCtx *zck_src = NULL;
+    int src_fd = -1;
+    if(arguments.source) {
+        src_fd = open(arguments.source, O_RDONLY | O_BINARY);
+        if(src_fd < 0) {
+            perror(arguments.source);
+            zck_free(&zck_tgt);
+            close(dst_fd);
+            exit(1);
+        }
+        zck_src = zck_create();
+        if(!zck_src) {
+            close(src_fd);
+            zck_free(&zck_tgt);
+            close(dst_fd);
+            exit(1);
+        }
+        if(!zck_init_read(zck_src, src_fd)) {
+            LOG_ERROR("Unable to open %s: %s", arguments.source,
+                      zck_get_error(zck_src));
+            zck_free(&zck_src);
+            close(src_fd);
+            zck_free(&zck_tgt);
+            close(dst_fd);
+            exit(1);
+        }
+    }
+
+    int valid = zck_find_valid_chunks(zck_tgt);
+    if(valid == 0) {
+        LOG_ERROR("%s", zck_get_error(zck_tgt));
+        zck_free(&zck_src);
+        if(src_fd >= 0)
+            close(src_fd);
+        zck_free(&zck_tgt);
+        close(dst_fd);
+        exit(1);
+    }
+
+    size_t imported = 0;
+    int remaining = 0;
+
+    if(valid != 1) {
+        if(zck_src && !zck_copy_chunks(zck_src, zck_tgt)) {
+            LOG_ERROR("%s", zck_get_error(zck_tgt));
+            zck_free(&zck_src);
+            if(src_fd >= 0)
+                close(src_fd);
+            zck_free(&zck_tgt);
+            close(dst_fd);
+            exit(1);
+        }
+
+        zck_reset_failed_chunks(zck_tgt);
+
+    const char *hash_name = zck_hash_name_from_type(zck_get_chunk_hash_type(zck_tgt));
+    char hash_dir[128];
+    hash_to_dir_name(hash_name, hash_dir, sizeof(hash_dir));
+        ssize_t chunk_count = zck_get_chunk_count(zck_tgt);
+        for(ssize_t i = 0; i < chunk_count; i++) {
+            zckChunk *chunk = zck_get_chunk(zck_tgt, i);
+            if(!chunk)
+                continue;
+            if(zck_get_chunk_valid(chunk) == 1)
+                continue;
+            ssize_t comp_len = zck_get_chunk_comp_size(chunk);
+            if(comp_len == 0)
+                continue;
+            char *digest = zck_get_chunk_digest(chunk);
+            bool uncompressed = false;
+            if(!digest) {
+                LOG_ERROR("%s", zck_get_error(zck_tgt));
+                continue;
+            }
+            if(digest_all_zero(digest)) {
+                free(digest);
+                digest = zck_get_chunk_digest_uncompressed(chunk);
+                uncompressed = true;
+                if(!digest) {
+                    LOG_ERROR("%s", zck_get_error(zck_tgt));
+                    continue;
+                }
+            }
+
+            char chunk_path[PATH_MAX];
+            if(!build_chunk_path(chunk_path, sizeof(chunk_path), arguments.chunk_dir,
+                                  hash_dir, digest, uncompressed)) {
+                if(!add_missing(&arguments, digest, uncompressed)) {
+                    fprintf(stderr, "Unable to record missing chunk\n");
+                    free(digest);
+                    zck_free(&zck_src);
+                    if(src_fd >= 0)
+                        close(src_fd);
+                    zck_free(&zck_tgt);
+                    close(dst_fd);
+                    exit(1);
+                }
+                free(digest);
+                continue;
+            }
+            int cfd = open(chunk_path, O_RDONLY | O_BINARY);
+            if(cfd < 0) {
+                if(!add_missing(&arguments, digest, uncompressed)) {
+                    fprintf(stderr, "Unable to record missing chunk\n");
+                    free(digest);
+                    zck_free(&zck_src);
+                    if(src_fd >= 0)
+                        close(src_fd);
+                    zck_free(&zck_tgt);
+                    close(dst_fd);
+                    exit(1);
+                }
+                free(digest);
+                continue;
+            }
+            if(!zck_import_chunk_from_fd(zck_tgt, chunk, cfd)) {
+                if(!add_missing(&arguments, digest, uncompressed)) {
+                    fprintf(stderr, "Unable to record missing chunk\n");
+                    close(cfd);
+                    free(digest);
+                    zck_free(&zck_src);
+                    if(src_fd >= 0)
+                        close(src_fd);
+                    zck_free(&zck_tgt);
+                    close(dst_fd);
+                    exit(1);
+                }
+            } else {
+                imported += (size_t)comp_len;
+            }
+            close(cfd);
+            free(digest);
+        }
+
+        remaining = zck_missing_chunks(zck_tgt);
+    } else {
+        remaining = 0;
+    }
+
+    printf("Missing chunks: %i\n", remaining);
+    printf("Imported %llu bytes from chunk directory\n",
+           (long long unsigned)imported);
+
+    int exit_code = 0;
+    if(remaining > 0) {
+        exit_code = 1;
+        if(arguments.missing_count > 0) {
+            printf("Chunks still required (%zu):\n", arguments.missing_count);
+            for(size_t i = 0; i < arguments.missing_count; i++) {
+                printf("    %s%s\n",
+                       arguments.missing[i].digest,
+                       arguments.missing[i].uncompressed ? " (uncompressed)" : "");
+            }
+        }
+    } else {
+        if(ftruncate(dst_fd, zck_get_length(zck_tgt)) < 0) {
+            perror("ftruncate");
+            zck_free(&zck_src);
+            if(src_fd >= 0)
+                close(src_fd);
+            zck_free(&zck_tgt);
+            close(dst_fd);
+            exit(1);
+        }
+        switch(zck_validate_data_checksum(zck_tgt)) {
+            case -1:
+            case 0:
+                LOG_ERROR("%s", zck_get_error(zck_tgt));
+                zck_free(&zck_src);
+                if(src_fd >= 0)
+                    close(src_fd);
+                zck_free(&zck_tgt);
+                close(dst_fd);
+                exit(1);
+            default:
+                break;
+        }
+        printf("Data checksum OK\n");
+    }
+
+    zck_free(&zck_src);
+    if(src_fd >= 0)
+        close(src_fd);
+    zck_free(&zck_tgt);
+    close(dst_fd);
+    for(size_t i = 0; i < arguments.missing_count; i++)
+        free(arguments.missing[i].digest);
+    free(arguments.missing);
+    return exit_code;
+}

--- a/test/abi/stable/zck.h
+++ b/test/abi/stable/zck.h
@@ -346,6 +346,16 @@ const ZCK_PUBLIC_API char *zck_hash_name_from_type(int hash_type)
 /* Get any matching chunks from src and put them in the right place in tgt */
 bool ZCK_PUBLIC_API zck_copy_chunks(zckCtx *src, zckCtx *tgt)
     ZCK_WARN_UNUSED;
+/* Overwrite chunk location with zeros */
+bool ZCK_PUBLIC_API zck_zero_chunk(zckCtx *tgt, zckChunk *chunk)
+    ZCK_WARN_UNUSED;
+/* Import chunk contents from an open file descriptor */
+bool ZCK_PUBLIC_API zck_import_chunk_from_fd(zckCtx *tgt, zckChunk *chunk, int fd)
+    ZCK_WARN_UNUSED;
+/* Import chunk contents from a file path */
+bool ZCK_PUBLIC_API zck_import_chunk_from_path(zckCtx *tgt, zckChunk *chunk,
+                                              const char *path)
+    ZCK_WARN_UNUSED;
 /* Free zckRange */
 void ZCK_PUBLIC_API zck_range_free(zckRange **info);
 /* Get range string from start and end location */

--- a/test/meson.build
+++ b/test/meson.build
@@ -108,6 +108,20 @@ test(
         '-V'
     ]
 )
+test(
+    'check version info in zck_chunk_store',
+    zck_chunk_store,
+    args: [
+        '-V'
+    ]
+)
+test(
+    'check version info in zckdir',
+    zckdir,
+    args: [
+        '-V'
+    ]
+)
 
 test(
     'check opening file with optional flags',
@@ -192,6 +206,18 @@ test(
         join_paths(file_path, 'LICENSE.header.new.nodict.fodt.zck'),
         join_paths(file_path, 'LICENSE.nodict.fodt.zck')
     ]
+)
+offline_script = files('offline_workflow.sh')
+test(
+    'offline chunk directory workflow',
+    find_program('sh'),
+    args: [
+        offline_script,
+        zck_chunk_store.full_path(),
+        zckdir.full_path(),
+        join_paths(file_path, 'LICENSE.dict.fodt.zck')
+    ],
+    is_parallel: false
 )
 test(
     'decompress previously generated auto-chunked file - nocomp',

--- a/test/offline_workflow.sh
+++ b/test/offline_workflow.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+chunk_store_bin=$1
+zckdir_bin=$2
+sample=$3
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT INT TERM
+
+chunk_dir="$workdir/cache"
+mkdir -p "$chunk_dir"
+
+"$chunk_store_bin" "$chunk_dir" "$sample"
+
+header_path="$chunk_dir/headers/$(basename "$sample").header"
+out_path="$workdir/output.zck"
+
+"$zckdir_bin" --chunk-dir "$chunk_dir" --header "$header_path" "$out_path"
+
+cmp "$sample" "$out_path"


### PR DESCRIPTION
## Summary
- add the zck_chunk_store utility to export headers and compressed chunks into a reusable cache directory
- add the zckdir utility to rebuild a zchunk file from a cache, optional source file, and header copy
- expose chunk import helpers in libzck and document and test the offline workflow

## Testing
- /usr/bin/ninja -C build test

------
https://chatgpt.com/codex/tasks/task_e_68cdb3d98830832ea4d3f0be2a651381